### PR TITLE
Adding new Application ID requirements

### DIFF
--- a/Citrix.Unified.Api.Test.WebClient/Pages/Index.cshtml
+++ b/Citrix.Unified.Api.Test.WebClient/Pages/Index.cshtml
@@ -13,7 +13,7 @@
             @foreach (var resource in Model.Resources)
             {
                 <div class="card-item" onclick="PerformLaunch(this)" data-launchIca="@Model.Protect(@resource.Links.LaunchUrl)">
-                    <img src="@resource.Links.ImageUrl" alt=""/>
+                    <img src="@Model.AddApplicationIdToNonCdnImageEndpoint(resource.Links.ImageUrl)" alt="" />
                     <div class="card-item-footer">
                         @resource.Name
                         <form asp-page="Launch" method="post" target="_blank">

--- a/Citrix.Unified.Api.Test.WebClient/Pages/Index.cshtml.cs
+++ b/Citrix.Unified.Api.Test.WebClient/Pages/Index.cshtml.cs
@@ -1,4 +1,8 @@
-﻿// Copyright © 2023. Cloud Software Group, Inc. All Rights Reserved.
+﻿/*
+* Copyright © 2023. Cloud Software Group, Inc.
+* This file is subject to the license terms contained
+* in the license file that is distributed with this file.
+*/
 
 using Citrix.Unified.Api.Test.WebClient.CitrixOidc;
 using Citrix.Unified.Api.Test.WebClient.Resources;

--- a/Citrix.Unified.Api.Test.WebClient/Pages/Index.cshtml.cs
+++ b/Citrix.Unified.Api.Test.WebClient/Pages/Index.cshtml.cs
@@ -1,8 +1,4 @@
-﻿/*
-* Copyright © 2023. Cloud Software Group, Inc.
-* This file is subject to the license terms contained
-* in the license file that is distributed with this file.
-*/
+﻿// Copyright © 2023. Cloud Software Group, Inc. All Rights Reserved.
 
 using Citrix.Unified.Api.Test.WebClient.CitrixOidc;
 using Citrix.Unified.Api.Test.WebClient.Resources;
@@ -10,6 +6,7 @@ using Citrix.Unified.Api.Test.WebClient.Resources;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
 
 namespace Citrix.Unified.Api.Test.WebClient.Pages;
 
@@ -19,12 +16,14 @@ public class IndexModel : PageModel
     private readonly ILogger<IndexModel> _logger;
     private readonly ResourcesClient _resourcesClient;
     private readonly IDataProtectionProvider _dataProtectionProvider;
+    private readonly string _applicationId;
 
-    public IndexModel(ILogger<IndexModel> logger, ResourcesClient resourcesClient, IDataProtectionProvider dataProtectionProvider)
+    public IndexModel(ILogger<IndexModel> logger, ResourcesClient resourcesClient, IDataProtectionProvider dataProtectionProvider, IOptionsMonitor<OidcSettings> oidcSettings)
     {
         _logger = logger;
         _resourcesClient = resourcesClient;
         _dataProtectionProvider = dataProtectionProvider;
+        _applicationId = oidcSettings.CurrentValue.ApplicationId;
     }
 
     public string? Domain { get; set; }
@@ -53,6 +52,18 @@ public class IndexModel : PageModel
         }
 
         return Page();
+    }
+
+    public string AddApplicationIdToNonCdnImageEndpoint(string url)
+    {
+        if (url.Contains("api/store/resources/images"))
+        {
+            return url + "?ApplicationId=" + _applicationId;
+        }
+        else
+        {
+            return url;
+        }
     }
 
     public string Protect(string url)

--- a/Citrix.Unified.Api.Test.WebClient/Pages/Launch.cshtml.cs
+++ b/Citrix.Unified.Api.Test.WebClient/Pages/Launch.cshtml.cs
@@ -1,4 +1,8 @@
-﻿// Copyright © 2023. Cloud Software Group, Inc. All Rights Reserved.
+﻿/*
+* Copyright © 2023. Cloud Software Group, Inc.
+* This file is subject to the license terms contained
+* in the license file that is distributed with this file.
+*/
 
 using System.ComponentModel.DataAnnotations;
 

--- a/Citrix.Unified.Api.Test.WebClient/Pages/Launch.cshtml.cs
+++ b/Citrix.Unified.Api.Test.WebClient/Pages/Launch.cshtml.cs
@@ -1,11 +1,6 @@
-﻿/*
-* Copyright © 2023. Cloud Software Group, Inc.
-* This file is subject to the license terms contained
-* in the license file that is distributed with this file.
-*/
+﻿// Copyright © 2023. Cloud Software Group, Inc. All Rights Reserved.
 
 using System.ComponentModel.DataAnnotations;
-using System.Text;
 
 using Citrix.Unified.Api.Test.WebClient.Resources;
 
@@ -72,10 +67,8 @@ namespace Citrix.Unified.Api.Test.WebClient.Pages
             {
                 case "success":
                     {
-                        var receiverUrl = BuildReceiverUrl(launchData);
-
-                        _logger.LogInformation("Sending to CWA url, {receiverUrl}", receiverUrl);
-                        return Redirect(receiverUrl);
+                        _logger.LogInformation("Sending to CWA url, {ReceiverUri}", launchData.ReceiverUri);
+                        return Redirect(launchData.ReceiverUri);
                     }
                 case "retry":
                     Retry = true;
@@ -89,36 +82,6 @@ namespace Citrix.Unified.Api.Test.WebClient.Pages
         public string UnProtect(string protectedUrl)
         {
             return _dataProtectionProvider.CreateProtector("LaunchStatusUrl").Unprotect(protectedUrl);
-        }
-
-        private static string BuildReceiverUrl(WspResourceLaunchDto launchData)
-        {
-            var queryString = QueryString.Create(new Dictionary<string, string?>()
-            {
-                {"action", "launch"},
-                {"transport", "https"},
-                {"serverProtocolVersion", launchData.ServerProtocolVersion},
-                {"ticket", launchData.FileFetchTicket}
-            });
-
-            if (launchData.FileFetchStaTicket != null)
-            {
-                queryString = queryString.Add("staTicket", launchData.FileFetchStaTicket);
-            }
-
-            var base64EncodedParameters = Convert.ToBase64String(Encoding.UTF8.GetBytes(queryString.ToUriComponent()))
-                .Replace("+", "_")
-                .Replace("/", "!")
-                .Replace("=", "-");
-
-            var fetchUrl = launchData.FileFetchUrl ?? throw new InvalidOperationException("FileFetch url should not be null");
-            var uriBuilder = new UriBuilder(fetchUrl);
-
-            uriBuilder.Scheme = "receiver";
-            uriBuilder.Path = uriBuilder.Path + "/" +
-                              base64EncodedParameters;
-
-            return uriBuilder.Uri.ToString();
         }
     }
 }

--- a/Citrix.Unified.Api.Test.WebClient/Program.cs
+++ b/Citrix.Unified.Api.Test.WebClient/Program.cs
@@ -72,7 +72,13 @@ services.AddDataProtection();
 
 services.AddHealthChecks();
 
-services.AddHttpClient(nameof(DiscoveryClient));
+services.AddHttpClient(nameof(DiscoveryClient), configureClient: client =>
+{
+    client.DefaultRequestHeaders.UserAgent.ParseAdd("Citrix WebApp Example - API HttpClient");
+    client.DefaultRequestHeaders.Add("Citrix-ApplicationId", oidcSettings.ApplicationId);
+})
+    .AddHttpMessageHandler<CitrixHttpMessageHandler>();
+    
 services.AddMemoryCache();
 services.AddSingleton<DiscoveryClient>();
 

--- a/Citrix.Unified.Api.Test.WebClient/Resources/WspResourcesDto.cs
+++ b/Citrix.Unified.Api.Test.WebClient/Resources/WspResourcesDto.cs
@@ -22,6 +22,7 @@ namespace Citrix.Unified.Api.Test.WebClient.Resources
         string? ServerProtocolVersion,
         string? FileFetchTicket,
         string? FileFetchStaTicket,
+        string? ReceiverUri,
         string? ErrorId,
         bool? SuggestRestart,
         string? RetryUrl


### PR DESCRIPTION
- Application IDs are being introduced as requirements via header or query parameter soon, and this adds that to the Image URL. 
- Instead of constructing the Receiver URL used for CWA based launch use the returned pre-constructed URL.  